### PR TITLE
Add armv6, armv7 and arm64 to goreleaser builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,8 @@ builds:
   - linux
   goarch:
   - amd64
+  - arm64
+  - armv6
   ldflags: []
 
 archive:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,10 @@ builds:
   goarch:
   - amd64
   - arm64
-  - armv6
+  - arm
+  goarm:
+  - 6
+  - 7
   ldflags: []
 
 archive:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
     - tip
 env:
     - GO111MODULE=on
+    - CGO_ENABLED=0
 install: true
 script:
   - go build


### PR DESCRIPTION
Added extra archs to .goreleaser.yml.

Updated .travis.yml to build without CGO because it is specified in .goreleaser.yml