### PR TITLE
Don't print trailing newline

### DIFF
--- a/mustache.go
+++ b/mustache.go
@@ -80,7 +80,7 @@ func main() {
 	checkErr(err)
 	output, err := mustache.RenderFile(templatePath, context...)
 	checkErr(err)
-	fmt.Println(output)
+	fmt.Print(output)
 }
 
 func checkErr(err error) {


### PR DESCRIPTION
The CLI does not currently respect the source input as it produces an extraneous trailing newline. This is a simple one-liner that fixes that.

Signed-off-by: Jacob Hull <jacob@planethull.com>